### PR TITLE
GitHub で一部の数式が描画されない現象を修正

### DIFF
--- a/IntroLQCDjpv1.ipynb
+++ b/IntroLQCDjpv1.ipynb
@@ -1,16 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e4438f8b-7fdd-4bb8-922d-52ad4176ba9c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import Pkg"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "7969f520-5531-4b3d-9264-937e37d6d52a",
    "metadata": {

--- a/IntroLQCDjpv1.ipynb
+++ b/IntroLQCDjpv1.ipynb
@@ -1,10 +1,19 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4438f8b-7fdd-4bb8-922d-52ad4176ba9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import Pkg"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "7969f520-5531-4b3d-9264-937e37d6d52a",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -101,22 +110,28 @@
    "source": [
     "# 多体系の量子論\n",
     "場の理論の雛形となる$N$体の量子力学を考えてみましょう。まずハミルトニアンは、\n",
+    "\n",
     "$$\n",
     "\\hat H = \\sum_{j=1}^{N}\n",
     "\\frac{1}{2m} \\hat{p}^2_j\n",
     "+\n",
     "V(\\hat q_1,\\cdots).\n",
     "$$\n",
+    "\n",
     "で与えられます。そして量子化は、\n",
+    "\n",
     "$$\n",
     "[\\hat{q}_j, \\hat{p}_k] = {\\rm i}\\hbar\\delta_{jk}\n",
     "$$\n",
+    "\n",
     "と課すことで行われます。\n",
     "また全体の最低エネルギー状態は各粒子の最低エネルギー状態のテンソル積で与えられるとすると\n",
     "わかりやすいかもしれません。\n",
+    "\n",
     "$$\n",
     "|0\\rangle_{\\rm tot} = \\bigotimes_{j=1}^{N}|0\\rangle_j = |0\\rangle_1\\otimes|0\\rangle_2\\otimes\\cdots\n",
     "$$\n",
+    "\n",
     "ただし$|\\cdot\\rangle_j$は$j$番目の演算子$\\hat{p}_j$や$\\hat{q}_j$などが作用する状態ベクトルです。\n",
     "(ただし真の基底状態はこの様な積状態でなく、エンタングルしている状態です)。\n",
     "\n",
@@ -128,19 +143,24 @@
     "=\n",
     "\\hat{H} |\\psi\\rangle \n",
     "$$\n",
+    "\n",
     "そして状態の時間発展はハミルトニアン$\\hat H$が陽に時間に依存しない場合、\n",
+    "\n",
     "$$\n",
     "|\\psi(t)\\rangle =  {\\rm e}^{-{\\rm i} \\frac{\\hat H}{\\hbar} t}|\\psi(0)\\rangle\n",
     "$$\n",
+    "\n",
     "の様な形式解を持ちます。\n",
     "\n",
     "物理量は演算子$O$として書かれましたが、ハイゼンベルク描像では、\n",
+    "\n",
     "$$\n",
     "O(t)=\n",
     "{\\rm e}^{{\\rm i} \\frac{\\hat H}{\\hbar} t}\n",
     "O(0)\n",
     "{\\rm e}^{-{\\rm i} \\frac{\\hat H}{\\hbar} t}\n",
     "$$\n",
+    "\n",
     "のように時間発展を受けます。"
    ]
   },
@@ -309,17 +329,21 @@
     "つまり虚時間でのグリーン関数を計算できればよいのですが、どうすればよいのでしょうか。もし$V[\\phi]$が2次までしかなければ本質的にガウス積分なので積分出来てしまいます。一方で現実的な問題では$4$次まであることが知られており、このままでは(経路)積分が実行できません。\n",
     "\n",
     "そこでよく使われるのが摂動論です。これは$4$次の項をテイラー展開してしまう方法で、場の経路積分ではなく、1次元積分で例えるなら以下の計算をすることになります。\n",
+    "\n",
     "$$\n",
+    "\\begin{aligned}\n",
     "\\int_{-\\infty}^{\\infty} {\\rm e}^{-\\frac{1}{2}x^2-\\lambda x^4} \n",
-    "=\n",
+    "&=\n",
     "\\int_{-\\infty}^{\\infty} {\\rm e}^{-\\frac{1}{2}x^2}{\\rm e}^{-\\lambda x^4},\\\\\n",
-    "=\n",
+    "&=\n",
     "\\int_{-\\infty}^{\\infty} {\\rm e}^{-\\frac{1}{2}x^2}\\left(\\sum_{n=0}^\\infty\\frac{(-\\lambda x^4)^{n}}{n!}\\right),\\\\\n",
-    "\\overset{?}=\n",
+    "&\\overset{?}=\n",
     "\\sum_{n=0}^\\infty\n",
     "\\frac{ (-\\lambda)^{n} }{n!}\n",
     "\\int_{-\\infty}^{\\infty} {\\rm e}^{-\\frac{1}{2}x^2}{x^{4n}}\n",
+    "\\end{aligned}\n",
     "$$\n",
+    "\n",
     "本質的には場の理論でも同じ変形をします。\n",
     "\n",
     "ここで$\\overset{?}=$の等号のところで無限和と積分を入れ替えてしまいました。もしこの等号が成立していれば各項毎にガウス積分で評価が出来てしまうのでハッピーなのですが、そうはなりません。この入れ替えは許されておらず、入れ替えたあとの級数は収束しない漸近級数となっています。もし$\\lambda$が十分小さければ適当な次数$n$までは$\\lambda$以外のところが相対的に小さく、次数を大きくとるたびに近似は改善していきます。\n",
@@ -611,6 +635,7 @@
     "と取れば良いことが知られています。\n",
     "\n",
     "この演算子は以下のようにゲージ変換をうけます。\n",
+    "\n",
     "$$\n",
     "\\Omega(x_1,x_2) \n",
     "\\to \\exp[{\\rm i}\\int_{x_1}^{x_2} (A_\\mu(x)-\\partial_\\mu \\alpha(x))dx ]\n",
@@ -620,6 +645,7 @@
     "\\Omega(x_1,x_2)\n",
     "{\\rm e}^{-{\\rm i}\\alpha(x_2)}\n",
     "$$\n",
+    "\n",
     "この非局所的な演算子$\\Omega(x_1,x_2) $をウィルソンライン (ウィルソン・シュウィンガー積分など)と呼びます。\n",
     "\n",
     "$x_1$と$x_2$が格子間隔$a$だけ離れている場合でも、ゲージ不変な場をいれて、\n",
@@ -851,6 +877,7 @@
    "metadata": {},
    "source": [
     "パイ中間子の完全系を挟むと、\n",
+    "\n",
     "$$\n",
     "\\begin{align}\n",
     "G(\\tau)\n",
@@ -897,15 +924,18 @@
     "|\\Omega\\rangle|^2,\n",
     "\\end{align}\n",
     "$$\n",
+    "\n",
     "そして$|Z_\\alpha|^2 = |\n",
     "\\langle \\vec{0}, \\alpha|\n",
     "\\pi(0,\\vec{0}) \n",
     "|\\Omega\\rangle|^2$とおき、また$\\alpha = 0$の状態が$\\alpha=1$の状態よりエネルギーが低いことを仮定すると、\n",
+    "\n",
     "$$\n",
     "G(\\tau)\n",
     "=\n",
     "\\frac{|Z_0|^2}{2 m_{0}} {\\rm e}^{-m_0 \\tau}+ \\cdots\n",
     "$$\n",
+    "\n",
     "を得ます。原点から離れると$1/m_0$を減衰率として指数関数的に相関が減衰していきます。"
    ]
   },
@@ -975,16 +1005,21 @@
     "経路積分に対応する状態和$\\sum_{s_1=\\pm1}\\sum_{s_2=\\pm1}\\sum_{s_3=\\pm1}\\sum_{s_4=\\pm1}$は$2^4=16$項です。\n",
     "\n",
     "逆温度を$\\beta$として、$(s_1,s_2,s_3,s_4)$という配位の同時確率は、\n",
+    "\n",
     "$$\n",
     "p(s_1,s_2,s_3,s_4) = {\\rm e}^{-\\beta H[s]}/Z\n",
     "$$\n",
+    "\n",
     "です。ただし\n",
+    "\n",
     "$$\n",
     "Z = \\sum_{s_1=\\pm1}\\sum_{s_2=\\pm1}\\sum_{s_3=\\pm1}\\sum_{s_4=\\pm1}{\\rm e}^{-\\beta H[s]}\n",
     "$$\n",
+    "\n",
     "です。\n",
     "\n",
     "$s_2,s_3,s_4$が決まっているときに$s_1$の確率は条件付き確率で、\n",
+    "\n",
     "$$\n",
     "p(s_1|s_2,s_3,s_4)\n",
     "=\\frac{p(s_1,s_2,s_3,s_4)}{p(s_2,s_3,s_4)}\n",
@@ -1002,10 +1037,12 @@
     "{\\rm e}^{-\\beta ( s_2+s_4 ) }\n",
     "}\n",
     "$$\n",
+    "\n",
     "となります。局所的なハミルトニアンの場合、隣接部分にしか確率がよりません。\n",
     "今の場合、$s_1$の生起確率は$s_2$と$s_4$にのみ依っています。なので$p(s_1|s_2,s_3,s_4)=p(s_1|s_2,s_4)$と書きましょう。\n",
     "\n",
     "$s_2=s_4 = 1$のときに$s_1$は、\n",
+    "\n",
     "$$\n",
     "p(s_1|s_2=1,s_4=1)\n",
     "=\\frac{{\\rm e}^{\\beta 2s_1 }}{\n",
@@ -1014,7 +1051,9 @@
     "{\\rm e}^{-\\beta 2 }\n",
     "}\n",
     "$$\n",
+    "\n",
     "と与えられ、$s_1=1$となる確率は、\n",
+    "\n",
     "$$\n",
     "p(s_1=1|s_2=1,s_4=1)\n",
     "=\\frac{{\\rm e}^{2\\beta}}{\n",
@@ -1023,6 +1062,7 @@
     "{\\rm e}^{-\\beta 2 }\n",
     "}\n",
     "$$\n",
+    "\n",
     "となります。\n",
     "\n",
     "この例を見ると、$s_1$を確率的に生成するには$s_2$と$s_4$が決まっていれば、条件付き確率をもちいて$s_1=1$か$s_1=-1$かを決めれます。\n",
@@ -1034,20 +1074,26 @@
     "もう少しきちんというと、任意のスピン配位を用意し、そして上記条件付き確率を用いて全てのスピンを順々に更新し、別のスピン配位を得て、\n",
     "何度も同手順を繰り返して多数のスピン配位を作り出します。$i番目の$スピン配位を$s^{(i)}$と呼ぶことにすると、\n",
     "期待値\n",
+    "\n",
     "$$\n",
     "\\langle O\\rangle = \n",
     "\\frac{1}{Z}\\sum_{s_1=\\pm1}\\sum_{s_2=\\pm1}\\sum_{s_3=\\pm1}\\sum_{s_4=\\pm1}{\\rm e}^{-\\beta H[s]}O[s]\n",
     "$$\n",
+    "\n",
     "は、配位の数を$N$個として\n",
+    "\n",
     "$$\n",
     "\\langle O\\rangle = \\lim_{N\\to \\infty} \\frac{1}{N}\\sum_{i=1}^N O[s^{(i)}]\n",
     "$$\n",
+    "\n",
     "と計算できます。このような手法を一般にマルコフ連鎖モンテカルロ法と言います。\n",
     "\n",
     "実際上は、$N$を無限にとれないため、\n",
+    "\n",
     "$$\n",
     "\\langle O\\rangle =\\frac{1}{N}\\sum_{i=1}^N O[s^{(i)}] + \\mathcal{O}\\big(\\frac{1}{\\sqrt{N}}\\big)\n",
     "$$\n",
+    "\n",
     "と評価されます。また初期配位の依存性を消すため、最初のいくつかの配位は捨てる必要があります(熱化時間と呼びます)。\n",
     "\n",
     "上記に示した熱浴法はゲージ理論に対しても使用可能ですが、クォークのループ効果は非局所的なためクォークのループ効果を取り込むときには熱浴法は使えません。以下ではクォークのループ効果$det(d+m)^2$を無視してゲージ場に対して熱浴法を用いて計算を行っていきます。"
@@ -1255,7 +1301,9 @@
   {
    "cell_type": "markdown",
    "id": "35f78eda-deb1-4385-b93e-d14264e6a486",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# 解析\n",
     "\n",
@@ -1269,10 +1317,32 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d8edf6bf-ab7f-4f3a-a9b4-7397a6d68379",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     ";ls -ltr measurements/Heatbath_L06060612_beta5.7_quenched"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a62b1950-7897-41aa-8f0a-3246cde35378",
+   "metadata": {},
+   "source": [
+    "シェルコマンドを用いず Julia のコードだけで完結させることもできます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea6fc5a-320f-4b10-b37c-2a15e88ef101",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "readdir(\"measurements/Heatbath_L06060612_beta5.7_quenched\")"
    ]
   },
   {
@@ -1287,17 +1357,41 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a87fbf68-6c40-4ab2-bc69-dd1b14790b14",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     ";cat measurements/Heatbath_L06060612_beta5.7_quenched/Pion_correlator.txt"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "87195784-8169-4b54-8bf2-371f6f328f5e",
+   "metadata": {},
+   "source": [
+    "Julia の `run` 関数を通しででも確認できる。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9c9f66b-1d4e-4803-b247-1a2f7dd5d1c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "run(`cat measurements/Heatbath_L06060612_beta5.7_quenched/Pion_correlator.txt`);"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "bc663f01-0647-4aab-8484-a702372ddd0e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "Pkg.add(\"CSV\")\n",
@@ -1308,7 +1402,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "15ca97c4-9848-43d9-ada1-36baee90c36d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "using CSV\n",
@@ -1327,7 +1423,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "854164cd-1ac0-4ff4-ae55-85672117e0d6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "dir = \"./measurements/Heatbath_L06060612_beta5.7_quenched/\"\n",
@@ -1341,7 +1439,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "aa2e5cd8-8451-43cb-97da-79e62429ed30",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "Ndat = size(df, 1)\n",
@@ -1361,7 +1461,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cb2fcdaa-ec7b-4895-a775-12da313e58ef",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "using Statistics"
@@ -1379,7 +1481,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b7390053-bf0c-4a4d-ad88-2a8f32e8628c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "Gt = mean.(eachcol(df));\n",
@@ -1398,10 +1502,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1530762b-c8d4-4242-8fbf-19923a5f1085",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "import Pkg\n",
     "Pkg.add(\"Plots\")"
    ]
   },
@@ -1417,7 +1522,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8c3da2bf-0e04-4917-a1ab-cac2f63b1c7b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "using Plots\n",
@@ -1428,7 +1535,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "36eff477-7b92-460c-8fab-128ce440f9e2",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plot(xax,\n",
@@ -1451,7 +1560,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cbb47a05-5e6b-4a63-8d17-223d03d150b6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plot(xax,\n",
@@ -1492,7 +1603,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3412dfad-c036-41fb-b9c7-95ddb230d8b1",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "idx = collect(1:div(Nt,2) )\n",
@@ -1521,7 +1634,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "27debe2d-1fbb-4669-9fbf-3983136e52aa",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "idx = collect(4:div(Nt,2)+1 ) # \\tau=0がJulia では1番目のデータであることに注意。\n",
@@ -1557,7 +1672,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1ba2823-ce93-4ea0-b933-2e4f858776de",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "r0_over_a=2.922 # $\\beta=5.7$での次元なしの定数(r0/a)。論文(hep-lat/0108008)から。\n",
@@ -1592,7 +1709,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e3d86ae0-a16a-4c6f-b9e2-5a71fe34b267",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "println(\"mpi=$(round(a_inv*am, digits=2)) MeV\")"
@@ -1634,27 +1753,23 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f7b349a7-3340-4b65-b915-636bc83ad308",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "notebook_metadata_filter": "-all"
+  },
   "kernelspec": {
-   "display_name": "Julia 1.7.2",
+   "display_name": "Julia 1.8.4",
    "language": "julia",
-   "name": "julia-1.7"
+   "name": "julia-1.8"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.7.2"
+   "version": "1.8.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
```markdown
日本語の解説
$$
<適当な数式>
$$
日本語の解説
```

のように `$$` が詰まっていると (JupyterLab 上では描画されるものの) GitHub 上での数式の解釈が失敗してしまって適切に描画できないようです. 下記のように改行を入れておくと適切に描画できることがわかりました．

```markdown
日本語の解説

$$
<適当な数式>
$$

日本語の解説
```